### PR TITLE
stop validators from modifying the DOM

### DIFF
--- a/src/main/java/ca/nines/ise/validator/node/EndNodeValidator.java
+++ b/src/main/java/ca/nines/ise/validator/node/EndNodeValidator.java
@@ -66,10 +66,6 @@ public class EndNodeValidator extends TagNodeValidator<EndNode> {
               .addNote("End tag " + n.getName() + " should not occur.")
               .build();
       Log.addMessage(m);
-      DOM dom = n.getOwner();
-      if(dom != null) {
-          dom.remove(n);
-      }
     }
   }
 

--- a/src/main/java/ca/nines/ise/validator/node/StartNodeValidator.java
+++ b/src/main/java/ca/nines/ise/validator/node/StartNodeValidator.java
@@ -73,11 +73,6 @@ public class StartNodeValidator extends TagNodeValidator<StartNode> {
               .addNote("Start tag " + n.getName() + " should be self-closing.")
               .build();
       Log.addMessage(m);
-      DOM dom = n.getOwner();
-      if(dom != null) {
-          EmptyNode e = new EmptyNode(n);
-          dom.replace(n, e);
-      }
     }
     if (t.isDepreciated()) {
       Message m = Message.builder("validator.tag.depreciated")


### PR DESCRIPTION
`EndNodeValidator` and `StartNodeValidator` were modifying the DOM, causing a `java.util.ConcurrentModificationException` in `ca.nines.ise.validator.DOMValidator#validate`, line 81.

Validators should never modify the DOM -- that's what Transformers are for!