### PR TITLE
remove support for {P}

### DIFF
--- a/src/main/antlr4/ca/nines/ise/grammar/ISELexer.g4
+++ b/src/main/antlr4/ca/nines/ise/grammar/ISELexer.g4
@@ -26,7 +26,6 @@ ABBREVIATION : '|' ~'|'* '|' ;
 CHAR_UNICODE 
     : 
     ( '{s}'       // long/medial s        ſ     U+017F
-    | '{P}'       // pilcrow              ¶     U+00B6
     | '{r}'       // lower rotunda r      ꝛ     U+A75B
     | '{R}'       // upper rotunda r      Ꝛ     U+A75A
     | '{c}'       // lower c with cedilla ç     U+00E7

--- a/src/main/java/ca/nines/ise/node/chr/UnicodeCharNode.java
+++ b/src/main/java/ca/nines/ise/node/chr/UnicodeCharNode.java
@@ -38,7 +38,6 @@ public class UnicodeCharNode extends CharNode {
    */
   static {
     charMap.put("{s}", "\u017F");
-    charMap.put("{P}", "\u00B6");
     charMap.put("{r}", "\uA75B");
     charMap.put("{R}", "\uA75A");
     charMap.put("{c}", "\u00e7");


### PR DESCRIPTION
use literal unicode or named/numeric escapes instead