### PR TITLE
Expandedwriter

### DIFF
--- a/src/main/java/ca/nines/ise/cmd/Transform.java
+++ b/src/main/java/ca/nines/ise/cmd/Transform.java
@@ -30,6 +30,7 @@ import ca.nines.ise.writer.RTFWriter;
 import ca.nines.ise.writer.SGMLWriter;
 import ca.nines.ise.writer.TextWriter;
 import ca.nines.ise.writer.XMLWriter;
+import ca.nines.ise.writer.ExpandedSGMLWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
@@ -79,6 +80,9 @@ public class Transform extends Command {
     if(cmd.hasOption("sgml")) {
         renderer = new SGMLWriter(out);
     }
+    if(cmd.hasOption("ximl")) {
+        renderer = new ExpandedSGMLWriter(out);
+    }
 
     if (renderer == null) {
       System.err.println("You must specify a transformation");
@@ -126,6 +130,7 @@ public class Transform extends Command {
     opts.addOption("text", false, "Transform output to UTF-8 (unicode) text.");
     opts.addOption("rtf", false, "Transform output to an RTF document.");
     opts.addOption("sgml", false, "Transform output to an SGML document, after validating.");
+    opts.addOption("ximl", false, "Transform output to an SGML document with expanded tagging.");
     return opts;
   }
 

--- a/src/main/java/ca/nines/ise/writer/ExpandedSGMLWriter.java
+++ b/src/main/java/ca/nines/ise/writer/ExpandedSGMLWriter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2014 Michael Joyce <ubermichael@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package ca.nines.ise.writer;
+
+import ca.nines.ise.document.Annotation;
+import ca.nines.ise.dom.DOM;
+import ca.nines.ise.node.Node;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+
+/**
+ * SGMLWriter serializes a document into the ISE variant of SGML.
+ *
+ * @author Maxwell Terpstra <terpstra@alumni.uvic.ca>
+ */
+public class ExpandedSGMLWriter extends Writer {
+
+  /**
+   * Construct a writer and send output to STDOUT.
+   *
+   * @throws ParserConfigurationException
+   * @throws UnsupportedEncodingException
+   */
+  public ExpandedSGMLWriter() throws ParserConfigurationException, UnsupportedEncodingException {
+    this(new PrintStream(System.out, true, "UTF-8"));
+  }
+
+  /**
+   * Construct a writer and send output to the PrintStream.
+   *
+   * @param out output destination
+   */
+  public ExpandedSGMLWriter(PrintStream out) {
+    super(out);
+  }
+
+  /**
+   * Render the DOM into SGML with escapes expanded into unicode/markup.
+   *
+   * @param dom
+   */
+  @Override
+  public void render(DOM dom) throws IOException {
+    for (Node n : dom.expanded()) {
+        out.print(n.sgml());
+    }
+  }
+
+  /**
+   * This is unsupported.
+   *
+   * @param dom
+   * @param ann
+   * @throws TransformerConfigurationException
+   * @throws TransformerException
+   * @throws IOException
+   * @throws Exception
+   */
+  @Override
+  public void render(DOM dom, Annotation ann) throws TransformerConfigurationException, TransformerException, IOException, Exception {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+}


### PR DESCRIPTION
Adds a writer to output the "expanded" DOM as IML. This is useful for avoiding escape handling etc in our IML-to-TEI tools.